### PR TITLE
Programmatic api

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+// --
+// Packages
+
+const path = require('path');
+const arg = require('arg');
+const chalk = require('chalk').default;
+const Listr = require('listr');
+const getPort = require('get-port');
+const { watch } = require('chokidar');
+
+// --
+// Utils
+
+const help = require('./util/help');
+const getMdFilesInDir = require('./util/get-md-files-in-dir');
+const serveDirectory = require('./util/serve-dir');
+const config = require('./util/config');
+const { getDir } = require('./util/helpers');
+const mdToPdf = require('./util/md-to-pdf');
+
+// --
+// Configure CLI Arguments
+
+const args = arg({
+	'--help': Boolean,
+	'--version': Boolean,
+	'--watch': Boolean,
+	'--stylesheet': [String],
+	'--css': String,
+	'--body-class': [String],
+	'--highlight-style': String,
+	'--marked-options': String,
+	'--html-pdf-options': String,
+	'--pdf-options': String,
+	'--launch-options': String,
+	'--md-file-encoding': String,
+	'--stylesheet-encoding': String,
+	'--config-file': String,
+	'--devtools': Boolean,
+	'--debug': Boolean,
+
+	// aliases
+	'-h': '--help',
+	'-v': '--version',
+	'-w': '--watch',
+});
+
+// --
+// Main
+
+async function main(args, config) {
+	const input = args._[0];
+	const dest = args._[1];
+
+	if (args['--version']) {
+		return console.log(require('./package').version);
+	}
+
+	if (args['--help']) {
+		return help();
+	}
+
+	/**
+	 * throw warning when using --html-pdf-options flag
+	 * @todo remove in a future version
+	 */
+	if (args['--html-pdf-options']) {
+		console.warn(
+			[
+				chalk.red(`--html-pdf-options is not a valid argument anymore. Use --pdf-options instead.`),
+				chalk.gray(`valid options: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions`),
+			].join('\n'),
+		);
+	}
+
+	const mdFiles = input ? [input] : await getMdFilesInDir('.');
+
+	if (mdFiles.length === 0) {
+		return help();
+	}
+
+	if (dest) {
+		config.dest = dest;
+	}
+
+	// merge config from config file
+	if (args['--config-file']) {
+		try {
+			config = { ...config, ...require(path.resolve(args['--config-file'])) };
+		} catch (error) {
+			console.warn(chalk.red(`Warning: couldn't read config file: ${args['--config-file']}`));
+
+			if (args['--debug']) {
+				console.error(error);
+			}
+		}
+	}
+
+	// serve directory of first file because all files will be in the same dir
+	const port = await getPort();
+	const server = await serveDirectory(getDir(mdFiles[0]), port);
+
+	const getListrTask = mdFile => ({
+		title: `generating PDF from ${chalk.underline(mdFile)}`,
+		task: () => mdToPdf(mdFile, config, port, args),
+	});
+
+	// create list of tasks and run concurrently
+	await new Listr(mdFiles.map(getListrTask), { concurrent: true, exitOnError: false })
+		.run()
+		.then(() => {
+			if (args['--watch']) {
+				console.log(chalk.bgBlue('\n watching for changes \n'));
+
+				watch(mdFiles).on('change', async mdFile => {
+					await new Listr([getListrTask(mdFile)]).run().catch(error => args['--debug'] && console.error(error));
+				});
+			} else {
+				server.close();
+			}
+		})
+		.catch(error => (args['--debug'] && console.error(error)) || process.exit(1));
+}
+
+// --
+// Run
+
+main(args, config).catch(error => console.error(error) || process.exit(1));

--- a/index.js
+++ b/index.js
@@ -9,11 +9,15 @@ const mdToPdf = require('./util/md-to-pdf');
  * Convert a markdown file to PDF.
  *
  * @param {string} mdFile path to markdown file
- * @param {*} config config object
+ * @param {*} [config] config object
  *
  * @returns the path that the PDF was written to
  */
 module.exports = async (mdFile, config) => {
+	if (typeof mdFile !== 'string') {
+		throw new TypeError(`mdFile has to be a string, received ${typeof mdFile}`);
+	}
+
 	const port = await getPort();
 	const server = await serveDirectory(getDir(mdFile), port);
 

--- a/index.js
+++ b/index.js
@@ -1,176 +1,27 @@
-#!/usr/bin/env node
-
-// --
-// Packages
-
-const path = require('path');
-const arg = require('arg');
-const chalk = require('chalk').default;
-const Listr = require('listr');
-const grayMatter = require('gray-matter');
 const getPort = require('get-port');
-const { watch } = require('chokidar');
 
-// --
-// Utils
-
-const help = require('./util/help');
-const getMdFilesInDir = require('./util/get-md-files-in-dir');
-const readFile = require('./util/read-file');
+const defaultConfig = require('./util/config');
 const serveDirectory = require('./util/serve-dir');
-const getHtml = require('./util/get-html');
-const writePdf = require('./util/write-pdf');
-const config = require('./util/config');
-const { getMarginObject, getDir } = require('./util/helpers');
+const { getDir } = require('./util/helpers');
+const mdToPdf = require('./util/md-to-pdf');
 
-// --
-// Configure CLI Arguments
-
-const args = arg({
-	'--help': Boolean,
-	'--version': Boolean,
-	'--watch': Boolean,
-	'--stylesheet': [String],
-	'--css': String,
-	'--body-class': [String],
-	'--highlight-style': String,
-	'--marked-options': String,
-	'--html-pdf-options': String,
-	'--pdf-options': String,
-	'--launch-options': String,
-	'--md-file-encoding': String,
-	'--stylesheet-encoding': String,
-	'--config-file': String,
-	'--devtools': Boolean,
-	'--debug': Boolean,
-
-	// aliases
-	'-h': '--help',
-	'-v': '--version',
-	'-w': '--watch',
-});
-
-// --
-// Main
-
-async function main(args, config) {
-	const input = args._[0];
-	const output = args._[1];
-
-	if (args['--version']) {
-		return console.log(require('./package').version);
-	}
-
-	if (args['--help']) {
-		return help();
-	}
-
-	/**
-	 * throw warning when using --html-pdf-options flag
-	 * @todo remove in a future version
-	 */
-	if (args['--html-pdf-options']) {
-		console.warn(
-			[
-				chalk.red(`--html-pdf-options is not a valid argument anymore. Use --pdf-options instead.`),
-				chalk.gray(`valid options: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions`),
-			].join('\n'),
-		);
-	}
-
-	const mdFiles = input ? [input] : await getMdFilesInDir('.');
-
-	if (mdFiles.length === 0) {
-		return help();
-	}
-
-	// merge config from config file
-	if (args['--config-file']) {
-		try {
-			config = { ...config, ...require(path.resolve(args['--config-file'])) };
-		} catch (error) {
-			console.warn(chalk.red(`Warning: couldn't read config file: ${args['--config-file']}`));
-
-			if (args['--debug']) {
-				console.error(error);
-			}
-		}
-	}
-
-	// serve directory of first file because all files will be in the same dir
+/**
+ * Convert a markdown file to PDF.
+ *
+ * @param {string} mdFile path to markdown file
+ * @param {*} config config object
+ *
+ * @returns the path that the PDF was written to
+ */
+module.exports = async (mdFile, config) => {
 	const port = await getPort();
-	const server = await serveDirectory(getDir(mdFiles[0]), port);
+	const server = await serveDirectory(getDir(mdFile), port);
 
-	const getListrTask = mdFile => ({
-		title: `generating PDF from ${chalk.underline(mdFile)}`,
-		task: () => convertToPdf(mdFile),
-	});
+	config = { ...defaultConfig, ...config };
 
-	// create list of tasks and run concurrently
-	await new Listr(mdFiles.map(getListrTask), { concurrent: true, exitOnError: false })
-		.run()
-		.then(() => {
-			if (args['--watch']) {
-				console.log(chalk.bgBlue('\n watching for changes \n'));
+	const pdf = await mdToPdf(mdFile, config, port);
 
-				watch(mdFiles).on('change', async mdFile => {
-					await new Listr([getListrTask(mdFile)]).run().catch(error => args['--debug'] && console.error(error));
-				});
-			} else {
-				server.close();
-			}
-		})
-		.catch(error => (args['--debug'] && console.error(error)) || process.exit(1));
+	server.close();
 
-	// this is the actual function to convert a file
-	async function convertToPdf(mdFile) {
-		const mdFileContent = await readFile(path.resolve(mdFile), args['--md-file-encoding'] || config.md_file_encoding);
-
-		const { content: md, data: frontMatterConfig } = grayMatter(mdFileContent);
-
-		// merge front-matter config
-		config = { ...config, ...frontMatterConfig };
-
-		// sanitize array cli arguments
-		for (const option of ['stylesheet', 'body_class']) {
-			if (!Array.isArray(config[option])) {
-				config[option] = [config[option]].filter(value => Boolean(value));
-			}
-		}
-
-		// merge cli args into config
-		const jsonArgs = ['--marked-options', '--pdf-options', '--launch-options'];
-		for (const arg of Object.entries(args)) {
-			const [argKey, argValue] = arg;
-			const key = argKey.substring(2).replace(/-/g, '_');
-			config[key] = jsonArgs.includes(argKey) ? JSON.parse(argValue) : argValue;
-		}
-
-		// sanitize the margin in pdf_options
-		if (typeof config.pdf_options.margin === 'string') {
-			config.pdf_options.margin = getMarginObject(config.pdf_options.margin);
-		}
-
-		const highlightStylesheet = path.resolve(
-			path.dirname(require.resolve('highlight.js')),
-			'..',
-			'styles',
-			`${config.highlight_style}.css`,
-		);
-
-		config.stylesheet = [...new Set([...config.stylesheet, highlightStylesheet])];
-
-		const html = getHtml(md, config);
-
-		const pdf = await writePdf(mdFile, output, html, { ...config, port });
-
-		if (!pdf.filename) {
-			throw new Error(`Failed to create PDF`);
-		}
-	}
-}
-
-// --
-// Run
-
-main(args, config).catch(error => console.error(error) || process.exit(1));
+	return pdf;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2603,7 +2603,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -3814,7 +3814,7 @@
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
@@ -7480,7 +7480,7 @@
     },
     "regjsparser": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
@@ -8669,7 +8669,7 @@
         },
         "globby": {
           "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "release": "np --standard-version --changelog-file=changelog.md"
   },
   "bin": {
-    "md-to-pdf": "./index.js",
-    "md2pdf": "./index.js"
+    "md-to-pdf": "./cli.js",
+    "md2pdf": "./cli.js"
   },
   "author": "Simon Haenisch (https://simonhaenisch.com)",
   "license": "Unlicense",

--- a/util/config.js
+++ b/util/config.js
@@ -5,6 +5,11 @@ const path = require('path');
  */
 module.exports = {
 	/**
+	 * Optional destination path for the output file (should use `.pdf` extension).
+	 */
+	dest: null,
+
+	/**
 	 * List of css files to use for styling.
 	 */
 	stylesheet: [path.resolve(__dirname, '..', 'markdown.css')],

--- a/util/md-to-pdf.js
+++ b/util/md-to-pdf.js
@@ -1,0 +1,71 @@
+const path = require('path');
+const grayMatter = require('gray-matter');
+
+const readFile = require('./read-file');
+const getHtml = require('./get-html');
+const writePdf = require('./write-pdf');
+const { getMarginObject } = require('./helpers');
+
+/**
+ * Convert a markdown file to pdf.
+ *
+ * @param {string} mdFile path to the markdown file
+ * @param {*} config config object
+ * @param {number} port port that the server runs on
+ * @param {*} args arguments if used by CLI
+ *
+ * @returns an object containing the PDF's filename if it was written successfully
+ */
+module.exports = async (mdFile, config, port, args = {}) => {
+	const mdFileContent = await readFile(path.resolve(mdFile), args['--md-file-encoding'] || config.md_file_encoding);
+
+	const { content: md, data: frontMatterConfig } = grayMatter(mdFileContent);
+
+	// merge front-matter config
+	config = { ...config, ...frontMatterConfig };
+
+	// sanitize array cli arguments
+	for (const option of ['stylesheet', 'body_class']) {
+		if (!Array.isArray(config[option])) {
+			config[option] = [config[option]].filter(value => Boolean(value));
+		}
+	}
+
+	// merge cli args into config
+	const jsonArgs = ['--marked-options', '--pdf-options', '--launch-options'];
+	for (const arg of Object.entries(args)) {
+		const [argKey, argValue] = arg;
+		const key = argKey.substring(2).replace(/-/g, '_');
+
+		if (key === 'dest' && config.dest) {
+			// we already have a destination from the CLI args
+			continue;
+		}
+
+		config[key] = jsonArgs.includes(argKey) ? JSON.parse(argValue) : argValue;
+	}
+
+	// sanitize the margin in pdf_options
+	if (typeof config.pdf_options.margin === 'string') {
+		config.pdf_options.margin = getMarginObject(config.pdf_options.margin);
+	}
+
+	const highlightStylesheet = path.resolve(
+		path.dirname(require.resolve('highlight.js')),
+		'..',
+		'styles',
+		`${config.highlight_style}.css`,
+	);
+
+	config.stylesheet = [...new Set([...config.stylesheet, highlightStylesheet])];
+
+	const html = getHtml(md, config);
+
+	const pdf = await writePdf(mdFile, html, { ...config, port });
+
+	if (!pdf.filename) {
+		throw new Error(`Failed to create PDF`);
+	}
+
+	return pdf;
+};

--- a/util/write-pdf.js
+++ b/util/write-pdf.js
@@ -5,9 +5,9 @@ const getPdfFilePath = require('./get-pdf-file-path');
  * Create a PDF and write it to disk.
  *
  * @param {string} mdFilePath path to the source markdown file
- * @param {string} [outputPath] path that the PDF will be written to
  * @param {string} html HTML document as a string
  * @param {Object} config configuration object
+ * @param {string} [config.dest] path to write the output to
  * @param {number} config.port port that the server runs on
  * @param {string[]} config.stylesheet list of stylesheets (urls or paths)
  * @param {string} config.css string with CSS rules
@@ -15,11 +15,11 @@ const getPdfFilePath = require('./get-pdf-file-path');
  * @param {boolean} config.devtools show the Devtools instead of saving the PDF
  * @param {puppeteer.LaunchOptions} config.launch_options browser launch options
  *
- * @returns a promise that resolves once the file is written and contains the
+ * @returns a promise that resolves once the file is written that contains the
  * pdf's filename
  */
-module.exports = async (mdFilePath, outputPath, html, config) => {
-	const pdfFilePath = outputPath || getPdfFilePath(mdFilePath);
+module.exports = async (mdFilePath, html, config) => {
+	const pdfFilePath = config.dest || getPdfFilePath(mdFilePath);
 
 	const browser = await puppeteer.launch({ devtools: config.devtools, ...config.launch_options });
 


### PR DESCRIPTION
This refactors the main `convertToPdf` function and exposes it from `util/md-to-pdf.js`, so it can be shared between the new programmatic API and the CLI. The CLI has been moved to `cli.js` and `index.js` exposes a function wrapper around `mdToPdf` instead.

Closes #25