### PR TITLE
fix asterisk emphasis rendering by upgrading marked library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5106,9 +5106,9 @@
       }
     },
     "marked": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.1.tgz",
-      "integrity": "sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.2.tgz",
+      "integrity": "sha512-Eq9jyHbsyG+XGhtyV6Gch2KsTnVSGvVgxP7gUU5iBhzh6gZmtunfCKGrJQcvxT0MxMNJ4JcvUEcha+LJ5zMHow=="
     },
     "matcher": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "highlight.js": "10.1.2",
     "iconv-lite": "0.6.2",
     "listr": "0.14.3",
-    "marked": "1.1.1",
+    "marked": "1.1.2",
     "puppeteer": ">=2.0.0",
     "semver": "7.3.2",
     "serve-handler": "6.1.3"


### PR DESCRIPTION
marked v1.1.1 has a problem in rendering emphasis with asterisks (see
https://github.com/markedjs/marked/issues/1754).

For example,

    echo "*A pigeon*: a  type of *bird*" | md-to-pdf --as-html

renders as

    <body class="">
    <p><em>A pigeon</em>: a  type of <em>bird</em></p>
    </body></html>

instead of the expected:

    <body class="">
    <p><em>A pigeon*: a  type of *bird</em></p>
    </body></html>

Version 1.1.2 resolves this issue (see
https://github.com/markedjs/marked/issues/1754#issuecomment-713628483).