### PR TITLE
feat(api): allow multiple input files

### DIFF
--- a/src/test/api.spec.ts
+++ b/src/test/api.spec.ts
@@ -70,3 +70,16 @@ test('compile the MathJax test', async (t) => {
 	t.true(text.includes('a≠0'));
 });
 
+test('compile multiple files to pdf', async (t) => {
+	const testFile = resolve(__dirname, 'basic', 'test.md');
+
+	const pdfs = await mdToPdf({ paths: [testFile, testFile] });
+
+	t.is(pdfs.length, 2);
+
+	t.is(pdfs[0].filename, '');
+	t.is(pdfs[1].filename, '');
+
+	t.truthy(pdfs[0].content instanceof Buffer);
+	t.truthy(pdfs[1].content instanceof Buffer);
+});

--- a/src/test/api.type-spec.ts
+++ b/src/test/api.type-spec.ts
@@ -5,9 +5,15 @@ import { HtmlOutput, PdfOutput } from '../lib/generate-output';
 (async () => {
 	expectType<PdfOutput>(await mdToPdf({ content: 'foo' }));
 	expectType<PdfOutput>(await mdToPdf({ path: 'foo.md' }));
-
+	expectType<PdfOutput[]>(await mdToPdf({ paths: ['foo.md'] }));
 	expectType<PdfOutput>(await mdToPdf({ path: 'foo.md' }, { as_html: false }));
 
 	expectType<HtmlOutput>(await mdToPdf({ content: 'foo' }, { as_html: true }));
 	expectType<HtmlOutput>(await mdToPdf({ path: 'foo.md' }, { as_html: true }));
+	expectType<HtmlOutput[]>(await mdToPdf({ paths: ['foo.md'] }, { as_html: true }));
+
+	expectType<string | undefined>((await mdToPdf({ content: 'foo' })).filename);
+
+	expectType<Buffer>((await mdToPdf({ content: 'foo' })).content);
+	expectType<string>((await mdToPdf({ content: 'foo' }, { as_html: true })).content);
 })();


### PR DESCRIPTION
I don't really like this yet because this overrides `dest` to `''` so that all converted files are written to disk. Instead, it should return an `Array<Output>`.