### PR TITLE
Align puppeteer launch options with original method signature

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,7 +1,7 @@
 import { WatchOptions } from 'chokidar';
 import { MarkedOptions } from 'marked';
 import { resolve } from 'path';
-import { FrameAddScriptTagOptions, LaunchOptions, PDFOptions } from 'puppeteer';
+import { BrowserConnectOptions, BrowserLaunchArgumentOptions, FrameAddScriptTagOptions, LaunchOptions, PDFOptions,Product } from 'puppeteer';
 
 export const defaultConfig: Config = {
 	basedir: process.cwd(),
@@ -114,7 +114,7 @@ interface BasicConfig {
 	 *
 	 * @see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions
 	 */
-	launch_options: LaunchOptions;
+	launch_options: PuppeteerLaunchSignatureOptions;
 
 	/**
 	 * Markdown file encoding. Default: `utf-8`.
@@ -143,4 +143,9 @@ interface BasicConfig {
 	 * This is specifically useful when running into issues when editor plugins trigger additional saves after the initial save.
 	 */
 	watch_options?: WatchOptions;
+}
+
+type PuppeteerLaunchSignatureOptions = LaunchOptions & BrowserLaunchArgumentOptions & BrowserConnectOptions & {
+  product?: Product;
+  extraPrefsFirefox?: Record<string, unknown>;
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,7 +1,7 @@
 import { WatchOptions } from 'chokidar';
 import { MarkedOptions } from 'marked';
 import { resolve } from 'path';
-import { BrowserConnectOptions, BrowserLaunchArgumentOptions, FrameAddScriptTagOptions, LaunchOptions, PDFOptions,Product } from 'puppeteer';
+import { FrameAddScriptTagOptions, launch, PDFOptions } from 'puppeteer';
 
 export const defaultConfig: Config = {
 	basedir: process.cwd(),
@@ -114,7 +114,7 @@ interface BasicConfig {
 	 *
 	 * @see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions
 	 */
-	launch_options: PuppeteerLaunchSignatureOptions;
+	launch_options: PuppeteerLaunchOptions;
 
 	/**
 	 * Markdown file encoding. Default: `utf-8`.
@@ -145,7 +145,4 @@ interface BasicConfig {
 	watch_options?: WatchOptions;
 }
 
-type PuppeteerLaunchSignatureOptions = LaunchOptions & BrowserLaunchArgumentOptions & BrowserConnectOptions & {
-  product?: Product;
-  extraPrefsFirefox?: Record<string, unknown>;
-}
+export type PuppeteerLaunchOptions = Parameters<typeof launch>[0];

--- a/src/test/api.spec.ts
+++ b/src/test/api.spec.ts
@@ -69,3 +69,13 @@ test('compile the MathJax test', async (t) => {
 	t.true(text.startsWith('Formulas with MathJax'));
 	t.true(text.includes('a≠0'));
 });
+
+test('compile passing some Puppeteer args', async (t) => {
+  const pdf = await mdToPdf(
+    { path: resolve(__dirname, 'basic', 'test.md') },
+    { launch_options: { args: [ '--no-sandbox' ] } });
+
+  t.is(pdf.filename, '');
+  t.truthy(pdf.content);
+  t.truthy(pdf.content instanceof Buffer);
+});


### PR DESCRIPTION
I was trying to use the --no-sandbox option in a Docker image using the typescript library.

I've found that within BasicConfig the launch options that are passed down to puppeteer were only `LaunchOptions`.
But the launch method in puppeeter takes a broader type options as params:
https://github.com/puppeteer/puppeteer/blob/main/src/api-docs-entry.ts#L99

```
export declare function launch(
  options?: LaunchOptions &
    BrowserLaunchArgumentOptions &
    BrowserConnectOptions & {
      product?: Product;
      extraPrefsFirefox?: Record<string, unknown>;
    }
): Promise<Browser>;
```

With this PR I've aligned the puppeteer options type that are passed to md-to-pdf with the signature of the launch method.

And now I'm able to specify `launch_options: { args: [ '--no-sandbox' ] },` as md-to-pdf option:
```
const pdf = await mdToPdf(
  { path },
  {
    dest,
    launch_options: { args: [ '--no-sandbox' ] },
  }
)
```