### PR TITLE
feat(html): added the option to set the HTML document title

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,7 @@ pdf_options:
       }
     </style>
     <section>
+      <span class="title"></span>
       <span class="date"></span>
     </section>
   footerTemplate: |-
@@ -184,6 +185,7 @@ For default and advanced options see the following links. The default highlight.
 | `--basedir`             | `path/to/folder`                                                      |
 | `--stylesheet`          | `path/to/style.css`, `https://example.org/stylesheet.css`             |
 | `--css`                 | `body { color: tomato; }`                                             |
+| `--document-title`      | `Read me`                                                             |
 | `--body-class`          | `markdown-body`                                                       |
 | `--page-media-type`     | `print`                                                               |
 | `--highlight-style`     | `monokai`, `solarized-light`                                          |

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,7 @@ Options:
   --basedir ................ Base directory to be served by the file server
   --stylesheet ............. Path to a local or remote stylesheet (can be passed multiple times)
   --css .................... String of styles
+  --document-title ......... Name of the HTML Document.
   --body-class ............. Classes to be added to the body tag (can be passed multiple times)
   --page-media-type ........ Media type to emulate the page with (default: screen)
   --highlight-style ........ Style to be used by highlight.js (default: github)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ export const cliFlags = arg({
 	'--watch-options': String,
 	'--stylesheet': [String],
 	'--css': String,
+	'--document-title': String,
 	'--body-class': [String],
 	'--page-media-type': String,
 	'--highlight-style': String,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,6 +8,7 @@ export const defaultConfig: Config = {
 	stylesheet: [resolve(__dirname, '..', '..', 'markdown.css')],
 	script: [],
 	css: '',
+	document_title: '',
 	body_class: [],
 	page_media_type: 'screen',
 	highlight_style: 'github',
@@ -77,6 +78,11 @@ interface BasicConfig {
 	 * @see https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pageaddscripttagoptions
 	 */
 	script: FrameAddScriptTagOptions[];
+
+	/**
+	 * Name of the HTML Document.
+	 */
+	document_title: string;
 
 	/**
 	 * List of classes for the body tag.

--- a/src/lib/get-html.ts
+++ b/src/lib/get-html.ts
@@ -6,7 +6,7 @@ import { getMarked } from './get-marked-with-highlighter';
  */
 export const getHtml = (md: string, config: Config) => `<!DOCTYPE html>
 <html>
-<head><meta charset="utf-8"></head>
+<head><title>${config.document_title}</title><meta charset="utf-8"></head>
 <body class="${config.body_class.join(' ')}">
 ${getMarked(config.marked_options)(md)}
 </body>

--- a/src/lib/help.ts
+++ b/src/lib/help.ts
@@ -12,6 +12,7 @@ const helpText = `
     --basedir ${chalk.dim('................')} Base directory to be served by the file server
     --stylesheet ${chalk.dim('.............')} Path to a local or remote stylesheet (can be passed multiple times)
     --css ${chalk.dim('....................')} String of styles
+    --document-title ${chalk.dim('.........')} Name of the HTML Document.
     --body-class ${chalk.dim('.............')} Classes to be added to the body tag (can be passed multiple times)
     --page-media-type ${chalk.dim('........')} Media type to emulate the page with (default: screen)
     --highlight-style ${chalk.dim('........')} Style to be used by highlight.js (default: github)


### PR DESCRIPTION
Added the option to set the HTML Title. When generating the PDF the variable title is now set to be used in the headerTemplate and footerTemplate.