### PR TITLE
[cli] Pass `dest` via cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,7 @@ Options:
   -w, --watch .............. Watch the current file(s) for changes
   --watch-options .......... Options for Chokidar's watch call
   --basedir ................ Base directory to be served by the file server
+  --dest ................... Optional destination directory for the output file(s)
   --stylesheet ............. Path to a local or remote stylesheet (can be passed multiple times)
   --css .................... String of styles
   --document-title ......... Name of the HTML Document.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ export const cliFlags = arg({
 	'--help': Boolean,
 	'--version': Boolean,
 	'--basedir': String,
+	'--dest': String,
 	'--watch': Boolean,
 	'--watch-options': String,
 	'--stylesheet': [String],


### PR DESCRIPTION
Allows CLI users to pass a destination directory without a config file.