### PR TITLE
Use `highlight` option to enable highlighting

### DIFF
--- a/src/lib/get-marked-with-highlighter.ts
+++ b/src/lib/get-marked-with-highlighter.ts
@@ -11,7 +11,7 @@ export const getMarked = (options: marked.MarkedOptions) => {
 		// langPrefix: 'hljs language-' // utilizes the hljs CSS class
 	}
 
-	marked.setOptions({ highlightPatch, ...options});
+	marked.setOptions({ ...highlightPatch, ...options});
 
 	return marked;
 };

--- a/src/lib/get-marked-with-highlighter.ts
+++ b/src/lib/get-marked-with-highlighter.ts
@@ -2,19 +2,17 @@ import hljs from 'highlight.js';
 import { marked } from 'marked';
 
 export const getMarked = (options: marked.MarkedOptions) => {
-	const renderer = options.renderer ?? new marked.Renderer();
-
-	// only add if the renderer has no custom `code` property yet
-	if (!Object.prototype.hasOwnProperty.call(renderer, 'code')) {
-		renderer.code = (code, languageName) => {
-			// if the given language is not available in highlight.js, fall back to plaintext
-			const language = languageName && hljs.getLanguage(languageName) ? languageName : 'plaintext';
-
-			return `<pre><code class="hljs ${language}">${hljs.highlight(code, { language }).value}</code></pre>`;
-		};
+	const highlightPatch = {
+		highlight: function(code, lang) {
+			const hljs = require('highlight.js');
+			const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+			return hljs.highlight(code, { language }).value;
+		},
+		langPrefix: 'hljs '
+		// langPrefix: 'hljs language-' // utilizes the hljs CSS class
 	}
 
-	marked.setOptions({ ...options, renderer });
+	marked.setOptions({ highlightPatch, ...options});
 
 	return marked;
 };

--- a/src/lib/get-marked-with-highlighter.ts
+++ b/src/lib/get-marked-with-highlighter.ts
@@ -3,8 +3,7 @@ import { marked } from 'marked';
 
 export const getMarked = (options: marked.MarkedOptions) => {
 	const highlightPatch = {
-		highlight: function(code, lang) {
-			const hljs = require('highlight.js');
+		highlight: (code, lang) => {
 			const language = hljs.getLanguage(lang) ? lang : 'plaintext';
 			return hljs.highlight(code, { language }).value;
 		},


### PR DESCRIPTION
Ref: #114 

Previously modified `code` function of renderer which made the use of custom renderers kinda buggy. 

Now actually utilizes the `highlight` option.

If a user wishes to customize the `code` renderer while still utilizing highlighting, see [the marked implementation](https://github.com/markedjs/marked/blob/4afb228d956a415624c4e5554bb8f25d047676fe/src/Renderer.js#L15-L39) for reference