### PR TITLE
feat: pass custom extension to marked

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -37,6 +37,7 @@ export const defaultConfig: Config = {
 	stylesheet_encoding: 'utf-8',
 	as_html: false,
 	devtools: false,
+	marked_extensions: []
 };
 
 /**
@@ -165,6 +166,13 @@ interface BasicConfig {
 	 * This is specifically useful when running into issues when editor plugins trigger additional saves after the initial save.
 	 */
 	watch_options?: WatchOptions;
+
+	/**
+	 * Custm Extensions to be passed to marked.
+	 * 
+	 * See https://marked.js.org/using_pro#extensions
+	 */
+	 marked_extensions: marked.MarkedExtension[]
 }
 
 export type PuppeteerLaunchOptions = Parameters<typeof launch>[0];

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -37,7 +37,7 @@ export const defaultConfig: Config = {
 	stylesheet_encoding: 'utf-8',
 	as_html: false,
 	devtools: false,
-	marked_extensions: []
+	marked_extensions: [],
 };
 
 /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -170,9 +170,9 @@ interface BasicConfig {
 	/**
 	 * Custm Extensions to be passed to marked.
 	 * 
-	 * See https://marked.js.org/using_pro#extensions
+	 * @see https://marked.js.org/using_pro#extensions
 	 */
-	 marked_extensions: marked.MarkedExtension[]
+	 marked_extensions: marked.MarkedExtension[];
 }
 
 export type PuppeteerLaunchOptions = Parameters<typeof launch>[0];

--- a/src/lib/get-html.ts
+++ b/src/lib/get-html.ts
@@ -8,7 +8,7 @@ export const getHtml = (md: string, config: Config) => `<!DOCTYPE html>
 <html>
 	<head><title>${config.document_title}</title><meta charset="utf-8"></head>
 	<body class="${config.body_class.join(' ')}">
-		${getMarked(config.marked_options)(md)}
+		${getMarked(config.marked_options, config.marked_extensions)(md)}
 	</body>
 </html>
 `;

--- a/src/lib/get-marked-with-highlighter.ts
+++ b/src/lib/get-marked-with-highlighter.ts
@@ -1,7 +1,7 @@
 import hljs from 'highlight.js';
 import { marked } from 'marked';
 
-export const getMarked = (options: marked.MarkedOptions) => {
+export const getMarked = (options: marked.MarkedOptions, extensions: marked.MarkedExtension[]) => {
 	marked.setOptions({
 		highlight: (code, languageName) => {
 			const language = hljs.getLanguage(languageName) ? languageName : 'plaintext';
@@ -11,6 +11,6 @@ export const getMarked = (options: marked.MarkedOptions) => {
 		langPrefix: 'hljs ',
 		...options,
 	});
-
+	marked.use(...extensions);
 	return marked;
 };


### PR DESCRIPTION
Ths PR allows the user to pass a custom extension to the marked parser.
see https://marked.js.org/using_pro#extensions