### PR TITLE
feat: use browser context #138

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,7 +65,6 @@ main(cliFlags, defaultConfig).catch((error) => {
 
 async function main(args: typeof cliFlags, config: Config) {
 	setProcessAndTermTitle('md-to-pdf');
-	const browser = await puppeteer.launch({ devtools: config.devtools, ...config.launch_options });
 
 	if (!validateNodeVersion()) {
 		throw new Error('Please use a Node.js version that satisfies the version specified in the engines field.');
@@ -125,6 +124,7 @@ async function main(args: typeof cliFlags, config: Config) {
 	/**
 	 * 4. Either process stdin or create a Listr task for each file.
 	 */
+	const browser = await puppeteer.launch({ devtools: config.devtools, ...config.launch_options });
 
 	if (stdin) {
 		const stdContext = await browser.createIncognitoBrowserContext();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -128,7 +128,7 @@ async function main(args: typeof cliFlags, config: Config) {
 
 	if (stdin) {
 		const stdContext = await browser.createIncognitoBrowserContext();
-		await convertMdToPdf({ content: stdin }, config, args, stdContext)
+		await convertMdToPdf({ content: stdin }, config, stdContext, args)
 			.then(async () => closeServer(server))
 			.catch(async (error: Error) => {
 				await closeServer(server);
@@ -143,7 +143,7 @@ async function main(args: typeof cliFlags, config: Config) {
 	const listrContext = await browser.createIncognitoBrowserContext();
 	const getListrTask = (file: string) => ({
 		title: `generating ${args['--as-html'] ? 'HTML' : 'PDF'} from ${chalk.underline(file)}`,
-		task: async () => convertMdToPdf({ path: file }, config, args, listrContext),
+		task: async () => convertMdToPdf({ path: file }, config, listrContext, args),
 	});
 
 	await new Listr(files.map(getListrTask), { concurrent: true, exitOnError: false })

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export async function mdToPdf(input: Input, config: Partial<Config> = {}): Promi
 
 	const browser = await puppeteer.launch({ devtools: config.devtools, ...config.launch_options });
 	const md2pdfContext = await browser.createIncognitoBrowserContext();
-	const pdf = await convertMdToPdf(input, mergedConfig, undefined, md2pdfContext);
+	const pdf = await convertMdToPdf(input, mergedConfig, md2pdfContext);
 
 	server.close();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import getPort from 'get-port';
+import puppeteer from 'puppeteer';
 import { Config, defaultConfig, HtmlConfig, PdfConfig } from './lib/config';
 import { HtmlOutput, Output, PdfOutput } from './lib/generate-output';
 import { getDir } from './lib/helpers';
@@ -50,7 +51,9 @@ export async function mdToPdf(input: Input, config: Partial<Config> = {}): Promi
 
 	const server = await serveDirectory(mergedConfig);
 
-	const pdf = await convertMdToPdf(input, mergedConfig);
+	const browser = await puppeteer.launch({ devtools: config.devtools, ...config.launch_options });
+	const md2pdfContext = await browser.createIncognitoBrowserContext();
+	const pdf = await convertMdToPdf(input, mergedConfig, undefined, md2pdfContext);
 
 	server.close();
 

--- a/src/lib/generate-output.ts
+++ b/src/lib/generate-output.ts
@@ -16,15 +16,16 @@ interface BasicOutput {
 	filename: string | undefined;
 }
 
+interface GenerateOutputProps {
+	html: string;
+	relativePath: string;
+	config: PdfConfig | HtmlConfig | Config;
+	browser: puppeteer.BrowserContext;
+}
 /**
  * Generate the output (either PDF or HTML).
  */
-export async function generateOutput(html: string, relativePath: string, config: PdfConfig): Promise<PdfOutput>;
-export async function generateOutput(html: string, relativePath: string, config: HtmlConfig): Promise<HtmlOutput>;
-export async function generateOutput(html: string, relativePath: string, config: Config): Promise<Output>;
-export async function generateOutput(html: string, relativePath: string, config: Config): Promise<Output> {
-	const browser = await puppeteer.launch({ devtools: config.devtools, ...config.launch_options });
-
+export async function generateOutput({ html, relativePath, config, browser }: GenerateOutputProps): Promise<Output> {
 	const page = await browser.newPage();
 
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -64,8 +65,6 @@ export async function generateOutput(html: string, relativePath: string, config:
 		await page.emulateMediaType(config.page_media_type);
 		outputFileContent = await page.pdf(config.pdf_options);
 	}
-
-	await browser.close();
 
 	return config.devtools ? (undefined as any) : { filename: config.dest, content: outputFileContent };
 }

--- a/src/lib/md-to-pdf.ts
+++ b/src/lib/md-to-pdf.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs';
 import grayMatter from 'gray-matter';
 import { dirname, resolve } from 'path';
+import puppeteer from 'puppeteer';
 import { Config } from './config';
 import { generateOutput } from './generate-output';
 import { getHtml } from './get-html';
@@ -17,6 +18,7 @@ export const convertMdToPdf = async (
 	input: { path: string } | { content: string },
 	config: Config,
 	args: CliArgs = {} as CliArgs,
+	browser: puppeteer.BrowserContext,
 ) => {
 	const mdFileContent =
 		'content' in input
@@ -87,7 +89,7 @@ export const convertMdToPdf = async (
 
 	const relativePath = 'path' in input ? resolve(input.path).replace(config.basedir, '') : '/';
 
-	const output = await generateOutput(html, relativePath, config);
+	const output = await generateOutput({ html, relativePath, config, browser });
 
 	if (!output) {
 		if (config.devtools) {

--- a/src/lib/md-to-pdf.ts
+++ b/src/lib/md-to-pdf.ts
@@ -17,8 +17,8 @@ type CliArgs = typeof import('../cli').cliFlags;
 export const convertMdToPdf = async (
 	input: { path: string } | { content: string },
 	config: Config,
-	args: CliArgs = {} as CliArgs,
 	browser: puppeteer.BrowserContext,
+	args: CliArgs = {} as CliArgs,
 ) => {
 	const mdFileContent =
 		'content' in input


### PR DESCRIPTION
This feature uses puppeteer.BrowserContext for the convertion tasks. Now, not for each task, an own browser instance is instantiated, but only one. This one and only is used, and only browserContexts are passed down to the convertion functions.
Reduces CPU Load, eliminates EventEmitter warnings and speed up conversion of large amount of files by ~50%.