### PR TITLE
refactor: use browser promise

### DIFF
--- a/src/lib/generate-output.ts
+++ b/src/lib/generate-output.ts
@@ -19,12 +19,15 @@ interface BasicOutput {
 /**
  * Store a single browser instance reference so that we can re-use it.
  */
-let browser: puppeteer.Browser | undefined;
+let browserInstance: Promise<puppeteer.Browser> | undefined;
 
 /**
  * Close the browser instance.
  */
-export const closeBrowser = () => browser?.close();
+export const closeBrowser = async () => {
+	const browser = await browserInstance;
+	if (browser) await browser.close();
+};
 
 /**
  * Generate the output (either PDF or HTML).
@@ -33,10 +36,11 @@ export async function generateOutput(html: string, relativePath: string, config:
 export async function generateOutput(html: string, relativePath: string, config: HtmlConfig): Promise<HtmlOutput>;
 export async function generateOutput(html: string, relativePath: string, config: Config): Promise<Output>;
 export async function generateOutput(html: string, relativePath: string, config: Config): Promise<Output> {
-	if (!browser) {
-		browser = await puppeteer.launch({ devtools: config.devtools, ...config.launch_options });
+	if (browserInstance === undefined) {
+		browserInstance = puppeteer.launch({ devtools: config.devtools, ...config.launch_options });
 	}
 
+	const browser = await browserInstance;
 	const page = await browser.newPage();
 
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
Found a solution for the race condition.

Use the global BrowserInstance as Promise, so each call can check if there is already an `launch` in progress and can wait.