### PR TITLE
feat: add new listr function with add capability

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,59 +2,23 @@
 
 // --
 // Packages
-
-import arg from 'arg';
 import chalk from 'chalk';
-import { watch, WatchOptions } from 'chokidar';
 import getPort from 'get-port';
 import getStdin from 'get-stdin';
-import Listr from 'listr';
 import path from 'path';
 import { PackageJson } from '.';
-import { Config, defaultConfig } from './lib/config';
+import handleListr from './cli/handleListr';
+import handleStdin from './cli/handleStdin';
+import { CliArgs, cliFlags, Config, defaultConfig } from './lib/config';
 import { closeBrowser } from './lib/generate-output';
 import { help } from './lib/help';
 import { setProcessAndTermTitle } from './lib/helpers';
-import { convertMdToPdf } from './lib/md-to-pdf';
+import { getConvertFactory } from './lib/md-to-pdf';
 import { closeServer, serveDirectory } from './lib/serve-dir';
 import { validateNodeVersion } from './lib/validate-node-version';
 
 // --
-// Configure CLI Arguments
-
-export const cliFlags = arg({
-	'--help': Boolean,
-	'--version': Boolean,
-	'--basedir': String,
-	'--watch': Boolean,
-	'--watch-options': String,
-	'--stylesheet': [String],
-	'--css': String,
-	'--document-title': String,
-	'--body-class': [String],
-	'--page-media-type': String,
-	'--highlight-style': String,
-	'--marked-options': String,
-	'--html-pdf-options': String,
-	'--pdf-options': String,
-	'--launch-options': String,
-	'--gray-matter-options': String,
-	'--port': Number,
-	'--md-file-encoding': String,
-	'--stylesheet-encoding': String,
-	'--as-html': Boolean,
-	'--config-file': String,
-	'--devtools': Boolean,
-
-	// aliases
-	'-h': '--help',
-	'-v': '--version',
-	'-w': '--watch',
-});
-
-// --
 // Run
-
 main(cliFlags, defaultConfig).catch((error) => {
 	console.error(error);
 	process.exit(1);
@@ -62,8 +26,7 @@ main(cliFlags, defaultConfig).catch((error) => {
 
 // --
 // Define Main Function
-
-async function main(args: typeof cliFlags, config: Config) {
+async function main(args: CliArgs, config: Config) {
 	setProcessAndTermTitle('md-to-pdf');
 
 	if (!validateNodeVersion()) {
@@ -109,6 +72,10 @@ async function main(args: typeof cliFlags, config: Config) {
 		}
 	}
 
+	if (args['--watch-timeout']) {
+		config.watch_timeout = args['--watch-timeout'];
+	}
+
 	/**
 	 * 3. Start the file server.
 	 */
@@ -125,52 +92,14 @@ async function main(args: typeof cliFlags, config: Config) {
 	 * 4. Either process stdin or create a Listr task for each file.
 	 */
 
+	const convertFactory = getConvertFactory(config, args);
 	if (stdin) {
-		await convertMdToPdf({ content: stdin }, config, args)
-			.finally(async () => {
-				await closeBrowser();
-				await closeServer(server);
-			})
-			.catch((error: Error) => {
-				throw error;
-			});
-
-		return;
+		await handleStdin(stdin, convertFactory);
+	} else {
+		await handleListr(files, convertFactory, args, config);
 	}
 
-	const getListrTask = (file: string) => ({
-		title: `generating ${args['--as-html'] ? 'HTML' : 'PDF'} from ${chalk.underline(file)}`,
-		task: async () => convertMdToPdf({ path: file }, config, args),
-	});
-
-	await new Listr(files.map(getListrTask), { concurrent: true, exitOnError: false })
-		.run()
-		.then(async () => {
-			if (args['--watch']) {
-				console.log(chalk.bgBlue('\n watching for changes \n'));
-
-				const watchOptions = args['--watch-options']
-					? (JSON.parse(args['--watch-options']) as WatchOptions)
-					: config.watch_options;
-
-				watch(files, watchOptions).on('change', async (file) =>
-					new Listr([getListrTask(file)], { exitOnError: false }).run().catch(console.error),
-				);
-			} else {
-				await closeBrowser();
-				await closeServer(server);
-			}
-		})
-		.catch((error: Error) => {
-			/**
-			 * In watch mode the error needs to be shown immediately because the `main` function's catch handler will never execute.
-			 *
-			 * @todo is this correct or does `main` actually finish and the process is just kept alive because of the file server?
-			 */
-			if (args['--watch']) {
-				return console.error(error);
-			}
-
-			throw error;
-		});
+	console.log('Exit.');
+	closeServer(server);
+	closeBrowser();
 }

--- a/src/cli/handleListr.ts
+++ b/src/cli/handleListr.ts
@@ -1,0 +1,142 @@
+import chalk from 'chalk';
+import { FSWatcher, watch, WatchOptions } from 'chokidar';
+import Listr from 'listr';
+import { CliArgs, Config } from '../lib/config';
+import { isMdFile } from '../lib/is-md-file';
+import { ConvertFactory } from '../lib/md-to-pdf';
+
+export default async function handleListr(
+	watchPath: string[],
+	convertFactory: ConvertFactory,
+	args: CliArgs,
+	config: Config,
+): Promise<void> {
+	const withWatch = args['--watch'];
+	const watchOptions = args['--watch-options']
+		? (JSON.parse(args['--watch-options']) as WatchOptions)
+		: config.watch_options;
+	const outputType = args['--as-html'] ? 'HTML' : 'PDF';
+
+	const watcher = watch(watchPath, watchOptions);
+	if (watchPath.length > 1) {
+		await legacyListrHandler(watchPath, outputType, convertFactory, watcher, withWatch);
+	} else {
+		await handleSinglePath(watcher, convertFactory, outputType, config, withWatch);
+	}
+	await watcher.close();
+	return;
+}
+
+const createListrTask = (
+	file: string,
+	outputType: 'HTML' | 'PDF',
+	convertFactory: ConvertFactory,
+): Listr.ListrTask => ({
+	title: `generating ${outputType} from ${chalk.underline(file)}`,
+	task: () => convertFactory({ path: file }),
+});
+
+const createAndRunListr = async (pathSet: Set<string>, convertFactory: ConvertFactory, outputType: 'HTML' | 'PDF') => {
+	try {
+		await new Listr(
+			Array.from(pathSet).map((path) => createListrTask(path, outputType, convertFactory)),
+			{ concurrent: true, exitOnError: false },
+		).run();
+	} catch (error) {
+		console.error(error);
+	}
+};
+
+const handleSinglePath = async (
+	watcher: FSWatcher,
+	convertFactory: ConvertFactory,
+	outputType: 'HTML' | 'PDF',
+	config: Config,
+	withWatch = false,
+) => {
+	/*
+	 * Run initial watch and listen for 'add' events.
+	 */
+	await new Promise<void>(async (resolve) => {
+		const pathSet: Set<string> = new Set<string>();
+		watcher.on('add', (path) => {
+			if (!isMdFile(path)) return;
+			pathSet.add(path);
+		});
+		watcher.on('ready', async () => {
+			await createAndRunListr(pathSet, convertFactory, outputType);
+			resolve();
+		});
+	});
+
+	if (!withWatch) {
+		return;
+	}
+
+	/*
+	 * Setup for running with --watch
+	 */
+	const pathSet: Set<string> = new Set<string>();
+	const timeOut = setTimeout(() => {
+		createAndRunListr(pathSet, convertFactory, outputType);
+		pathSet.clear();
+	}, config.watch_timeout);
+
+	const addOrChangeCallback = (path: string) => {
+		if (!isMdFile(path)) return;
+
+		pathSet.add(path);
+		timeOut.refresh();
+	};
+
+	console.log(chalk.bgBlue(`\n watching for changes with ${config.watch_timeout} ms watch_timeout \n`));
+	watcher.removeAllListeners();
+	watcher
+		.on('add', addOrChangeCallback)
+		.on('change', addOrChangeCallback)
+		.on('error', (error) => console.error(error));
+
+	/*
+	 * Keep this function open, until the programm gets exit code.
+	 */
+	return new Promise<void>(() => null);
+};
+
+const legacyListrHandler = async (
+	files: string[],
+	outputType: 'HTML' | 'PDF',
+	convertFactory: ConvertFactory,
+	watcher: FSWatcher,
+	withWatch = false,
+) => {
+	return await new Listr(
+		files.map((path) => createListrTask(path, outputType, convertFactory)),
+		{ concurrent: true, exitOnError: false },
+	)
+		.run()
+		.then(async () => {
+			if (withWatch) {
+				console.log(chalk.bgBlue('\n watching for changes \n'));
+
+				watcher.on('change', async (file) =>
+					new Listr([createListrTask(file, outputType, convertFactory)], { exitOnError: false })
+						.run()
+						.catch(console.error),
+				);
+
+				return new Promise<void>(() => null);
+			}
+		})
+		.catch((error: Error) => {
+			/**
+			 * In watch mode the error needs to be shown immediately because the `main` function's catch handler will never execute.
+			 *
+			 * @todo is this correct or does `main` actually finish and the process is just kept alive because of the file server?
+			 */
+			if (withWatch) {
+				return console.error(error);
+			}
+
+			throw error;
+		});
+};

--- a/src/cli/handleStdin.ts
+++ b/src/cli/handleStdin.ts
@@ -1,0 +1,7 @@
+import { ConvertFactory } from '../lib/md-to-pdf';
+
+export default async function handleStdin(content: string, convertFactory: ConvertFactory) {
+	await convertFactory({ content }).catch((error: Error) => {
+		throw error;
+	});
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,9 +1,51 @@
+import arg from 'arg';
 import { WatchOptions } from 'chokidar';
 import { GrayMatterOption } from 'gray-matter';
 import { marked } from 'marked';
 import { resolve } from 'path';
 import { FrameAddScriptTagOptions, launch, PDFOptions } from 'puppeteer';
 
+// --
+// Configure CLI Arguments
+export const cliFlags = arg({
+	'--help': Boolean,
+	'--version': Boolean,
+	'--basedir': String,
+	'--watch': Boolean,
+	'--watch-options': String,
+	'--watch-timeout': Number,
+	'--stylesheet': [String],
+	'--css': String,
+	'--document-title': String,
+	'--body-class': [String],
+	'--page-media-type': String,
+	'--highlight-style': String,
+	'--marked-options': String,
+	'--html-pdf-options': String,
+	'--pdf-options': String,
+	'--launch-options': String,
+	'--gray-matter-options': String,
+	'--port': Number,
+	'--md-file-encoding': String,
+	'--stylesheet-encoding': String,
+	'--as-html': Boolean,
+	'--config-file': String,
+	'--devtools': Boolean,
+
+	// aliases
+	'-h': '--help',
+	'-v': '--version',
+	'-w': '--watch',
+});
+
+/**
+ * Possible cliFlags
+ */
+export type CliArgs = typeof cliFlags;
+
+/*
+ * default Config that can be overwritten.
+ */
 export const defaultConfig: Config = {
 	basedir: process.cwd(),
 	stylesheet: [resolve(__dirname, '..', '..', 'markdown.css')],
@@ -38,6 +80,7 @@ export const defaultConfig: Config = {
 	as_html: false,
 	devtools: false,
 	marked_extensions: [],
+	watch_timeout: 250,
 };
 
 /**
@@ -173,6 +216,16 @@ interface BasicConfig {
 	 * @see https://marked.js.org/using_pro#extensions
 	 */
 	marked_extensions: marked.MarkedExtension[];
+
+	/**
+	 * Timeout (in ms) for delaying the change and add handler in watch mode.
+	 * Adjusts the timeout of the watcher events. If multiple 'add' or 'change' events are fired, before the timout exceeds,
+	 * the timeout gets resetted with each event.
+	 * The watcher collects all events, reduces them to unique events, and passes the tasks to the converter after timeout.
+	 * Shorter timeout could mean higher CPU and Memory load on big amount of events.
+	 * Default: 250 (ms)
+	 */
+	watch_timeout: number;
 }
 
 export type PuppeteerLaunchOptions = Parameters<typeof launch>[0];

--- a/src/lib/help.ts
+++ b/src/lib/help.ts
@@ -8,7 +8,8 @@ const helpText = `
     -h, --help ${chalk.dim('...............')} Output usage information
     -v, --version ${chalk.dim('............')} Output version
     -w, --watch ${chalk.dim('..............')} Watch the current file(s) for changes
-		--watch-options ${chalk.dim('..........')} Options for Chokidar's watch call
+    --watch-options ${chalk.dim('..........')} Options for Chokidar's watch call
+    --watch-timeout ${chalk.dim('..........')} Duration to buffer events for watcher in ms (default: 250)
     --basedir ${chalk.dim('................')} Base directory to be served by the file server
     --stylesheet ${chalk.dim('.............')} Path to a local or remote stylesheet (can be passed multiple times)
     --css ${chalk.dim('....................')} String of styles
@@ -19,7 +20,7 @@ const helpText = `
     --marked-options ${chalk.dim('.........')} Set custom options for marked (as a JSON string)
     --pdf-options ${chalk.dim('............')} Set custom options for the generated PDF (as a JSON string)
     --launch-options ${chalk.dim('.........')} Set custom launch options for Puppeteer
-		--gray-matter-options ${chalk.dim('....')} Set custom options for gray-matter
+    --gray-matter-options ${chalk.dim('....')} Set custom options for gray-matter
     --port ${chalk.dim('...................')} Set the port to run the http server on
     --md-file-encoding ${chalk.dim('.......')} Set the file encoding for the markdown file
     --stylesheet-encoding ${chalk.dim('....')} Set the file encoding for the stylesheet
@@ -33,21 +34,26 @@ const helpText = `
 
     ${chalk.cyan('$ md-to-pdf file.md')}
 
-  ${chalk.gray('–')} Convert all markdown files in current directory
+  ${chalk.gray('–')} Convert all markdown files in directory and recursive in all subdirectories 
+
+    ${chalk.cyan('$ md-to-pdf /path/to/folder')}
+    ${chalk.cyan('$ md-to-pdf .')}
+
+  ${chalk.gray('–')} Convert all markdown files in current directory 
 
     ${chalk.cyan('$ md-to-pdf ./*.md')}
 
-  ${chalk.gray('–')} Convert all markdown files in current directory recursively
+  ${chalk.gray('–')} Convert all markdown files in current directory recursively 
 
     ${chalk.cyan('$ md-to-pdf ./**/*.md')}
 
   ${chalk.gray('–')} Convert and enable watch mode
 
-    ${chalk.cyan('$ md-to-pdf ./*.md -w')}
+    ${chalk.cyan('$ md-to-pdf . -w')}
 
   ${chalk.gray('–')} Convert and enable watch mode with custom options
 
-    ${chalk.cyan('$ md-to-pdf ./*.md --watch --watch-options \'{ "atomic": true }\'')}
+    ${chalk.cyan('$ md-to-pdf . --watch --watch-options \'{ "atomic": true }\'')}
 
   ${chalk.gray('–')} Convert path/to/file.md with a different base directory
 

--- a/src/lib/is-md-file.ts
+++ b/src/lib/is-md-file.ts
@@ -1,4 +1,4 @@
-const extensions = /\.(md|mkd|mdown|markdown)(\.txt)?$/i;
+const extensions = /\.(md|mkd|mdown|markdown)$/i;
 
 /**
  * Check whether a path is a markdown file.

--- a/src/lib/md-to-pdf.ts
+++ b/src/lib/md-to-pdf.ts
@@ -1,14 +1,25 @@
 import { promises as fs } from 'fs';
 import grayMatter from 'gray-matter';
 import { dirname, resolve } from 'path';
-import { Config } from './config';
-import { generateOutput } from './generate-output';
+import { CliArgs, Config } from './config';
+import { generateOutput, Output } from './generate-output';
 import { getHtml } from './get-html';
 import { getOutputFilePath } from './get-output-file-path';
 import { getMarginObject } from './helpers';
 import { readFile } from './read-file';
 
-type CliArgs = typeof import('../cli').cliFlags;
+/**
+ * ConvertFactory is a factoryFunction which can be reused with config and args.
+ */
+export type ConvertFactory = (input: { path: string } | { content: string }) => Promise<Output>;
+
+/**
+ * Get a convertFactory function with config and args which are reuseable.
+ */
+export const getConvertFactory =
+	(config: Config, args: CliArgs): ConvertFactory =>
+	(input: { path: string } | { content: string }) =>
+		convertMdToPdf(input, config, args);
 
 /**
  * Convert markdown to pdf.


### PR DESCRIPTION
BREAKING CHANGE: It is now possible to give a folder as file argument e.g.: md2pdf $(pwd)

This works recursive. The watcher will listen for all add and change events in all subfolders, but only for markdown files.

For compatibility, a legacy function is kept alive, to handle multiple input paths, like ./**/*.md, so the old cli app works like before.