### PR TITLE
Do not emit process title to stdout

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,6 @@ import { PackageJson } from '.';
 import { Config, defaultConfig } from './lib/config';
 import { closeBrowser } from './lib/generate-output';
 import { help } from './lib/help';
-import { setProcessTitle } from './lib/helpers';
 import { convertMdToPdf } from './lib/md-to-pdf';
 import { closeServer, serveDirectory } from './lib/serve-dir';
 import { validateNodeVersion } from './lib/validate-node-version';
@@ -64,7 +63,7 @@ main(cliFlags, defaultConfig).catch((error) => {
 // Define Main Function
 
 async function main(args: typeof cliFlags, config: Config) {
-	setProcessTitle('md-to-pdf');
+	process.title = 'md-to-pdf';
 
 	if (!validateNodeVersion()) {
 		throw new Error('Please use a Node.js version that satisfies the version specified in the engines field.');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ import { PackageJson } from '.';
 import { Config, defaultConfig } from './lib/config';
 import { closeBrowser } from './lib/generate-output';
 import { help } from './lib/help';
-import { setProcessAndTermTitle } from './lib/helpers';
+import { setProcessTitle } from './lib/helpers';
 import { convertMdToPdf } from './lib/md-to-pdf';
 import { closeServer, serveDirectory } from './lib/serve-dir';
 import { validateNodeVersion } from './lib/validate-node-version';
@@ -64,7 +64,7 @@ main(cliFlags, defaultConfig).catch((error) => {
 // Define Main Function
 
 async function main(args: typeof cliFlags, config: Config) {
-	setProcessAndTermTitle('md-to-pdf');
+	setProcessTitle('md-to-pdf');
 
 	if (!validateNodeVersion()) {
 		throw new Error('Please use a Node.js version that satisfies the version specified in the engines field.');

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -30,7 +30,3 @@ export const getMarginObject = (margin: string): PDFOptions['margin'] => {
 		? { top, right: top, bottom: top, left: top }
 		: undefined;
 };
-
-export const setProcessTitle = (title: string) => {
-	process.title = title;
-};

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -31,7 +31,6 @@ export const getMarginObject = (margin: string): PDFOptions['margin'] => {
 		: undefined;
 };
 
-export const setProcessAndTermTitle = (title: string) => {
+export const setProcessTitle = (title: string) => {
 	process.title = title;
-	process.stdout.write(`${String.fromCharCode(27)}]0;${title}${String.fromCharCode(7)}`);
 };

--- a/src/test/lib.spec.ts
+++ b/src/test/lib.spec.ts
@@ -6,7 +6,7 @@ import { defaultConfig } from '../lib/config';
 import { getHtml } from '../lib/get-html';
 import { getMarked } from '../lib/get-marked-with-highlighter';
 import { getOutputFilePath } from '../lib/get-output-file-path';
-import { getDir, getMarginObject, setProcessTitle } from '../lib/helpers';
+import { getDir, getMarginObject } from '../lib/helpers';
 import { isHttpUrl } from '../lib/is-http-url';
 import { isMdFile } from '../lib/is-md-file';
 import { readFile } from '../lib/read-file';
@@ -21,10 +21,6 @@ test("gray-matter's js engine is disabled by default", (t) => {
 
 // --
 // helpers
-
-test('setProcessTitle should not throw', (t) => {
-	t.notThrows(() => setProcessTitle('md-to-pdf tests'));
-});
 
 test('getDir should get the directory the given file is in', (t) => {
 	const filePath = posix.join('/', 'var', 'foo', 'bar.txt');

--- a/src/test/lib.spec.ts
+++ b/src/test/lib.spec.ts
@@ -6,7 +6,7 @@ import { defaultConfig } from '../lib/config';
 import { getHtml } from '../lib/get-html';
 import { getMarked } from '../lib/get-marked-with-highlighter';
 import { getOutputFilePath } from '../lib/get-output-file-path';
-import { getDir, getMarginObject, setProcessAndTermTitle } from '../lib/helpers';
+import { getDir, getMarginObject, setProcessTitle } from '../lib/helpers';
 import { isHttpUrl } from '../lib/is-http-url';
 import { isMdFile } from '../lib/is-md-file';
 import { readFile } from '../lib/read-file';
@@ -22,8 +22,8 @@ test("gray-matter's js engine is disabled by default", (t) => {
 // --
 // helpers
 
-test('setProcessAndTermTitle should not throw', (t) => {
-	t.notThrows(() => setProcessAndTermTitle('md-to-pdf tests'));
+test('setProcessTitle should not throw', (t) => {
+	t.notThrows(() => setProcessTitle('md-to-pdf tests'));
 });
 
 test('getDir should get the directory the given file is in', (t) => {


### PR DESCRIPTION
Redirecting stdout into a target file is a common cli operation.

```sh
cat file.md | md-to-pdf > path/to/output.pdf
```

When the cli sets the process title, the helper util emits to `stdout`, which prepends a few bytes before the standard `%PDF-#.#` comment in the final PDF:

```
<0x1b>]0;md-to-pdf<0x07>%PDF-1.4
```



Most readers seem to ignore these bytes, but it's common for some tools to read a few bytes to determine if a file is a PDF.

Omitting the title seems like a sane strategy as I don't think it serves any useful purpose beyond cosmetic.

