### PR TITLE
fix(headless): puppeteer with headless option

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -24,7 +24,7 @@ export const defaultConfig: Config = {
 			left: '20mm',
 		},
 	},
-	launch_options: {},
+	launch_options: {args: ['--no-sandbox', '--disable-setuid-sandbox'],},
 	gray_matter_options: {
 		engines: {
 			js: () =>


### PR DESCRIPTION
#### puppeteer head less not found error in ubuntu/linux x86_64 GNU/Linux


operating system
```
Distributor ID: Ubuntu
Description:    Ubuntu 24.04 LTS
Release:        24.04
Codename:       noble
```
kernel version `6.8.0-35-generic`

when trying to convert md to pdf using cli , it gives no headless found error
following the suggestion from 
https://pptr.dev/troubleshooting#setting-up-chrome-linux-sandbox
the launch option is updated to use headless explicitly