### PR TITLE
Update get-marked-with-highlighter.ts

### DIFF
--- a/src/lib/get-marked-with-highlighter.ts
+++ b/src/lib/get-marked-with-highlighter.ts
@@ -1,16 +1,21 @@
 import hljs from 'highlight.js';
 import { marked } from 'marked';
 
-export const getMarked = (options: marked.MarkedOptions, extensions: marked.MarkedExtension[]) => {
-	marked.setOptions({
-		highlight: (code, languageName) => {
-			const language = hljs.getLanguage(languageName) ? languageName : 'plaintext';
-
-			return hljs.highlight(code, { language }).value;
-		},
-		langPrefix: 'hljs ',
-		...options,
-	});
-	marked.use(...extensions);
-	return marked;
+export const getMarked = (
+  options: marked.MarkedOptions,
+  extensions: marked.MarkedExtension[] = [],
+  useHighlightJs: boolean = false
+) => {
+  marked.setOptions({
+    ...options,
+    highlight: useHighlightJs
+      ? (code, languageName) => {
+          const language = hljs.getLanguage(languageName) ? languageName : 'plaintext';
+          return hljs.highlight(code, { language }).value;
+        }
+      : false,
+    langPrefix: useHighlightJs ? 'hljs ' : '',
+  });
+  if (extensions.length) marked.use(...extensions);
+  return marked;
 };


### PR DESCRIPTION
This refactor introduces a utility function getMarked that allows you to conditionally enable or disable syntax highlighting for Markdown code blocks using `highlight.js ` and marked. The function accepts a `useHighlightJs` boolean flag:

If useHighlightJs is true, code blocks in Markdown will be highlighted using highlight.js.
If useHighlightJs is false, code blocks will be rendered as plain text without syntax highlighting.
This makes it easy to toggle code highlighting based on user preference or API input, and keeps your Markdown rendering logic clean and flexible.