### PR TITLE
feat: add `wait_for_function` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
   "xo": {
     "prettier": true,
     "ignores": [
-      "src/test/mathjax"
+      "src/test/mathjax",
+      "src/test/mermaid"
     ],
     "rules": {
       "@typescript-eslint/explicit-function-return-type": "off",

--- a/readme.md
+++ b/readme.md
@@ -170,6 +170,35 @@ Refer to the Puppeteer docs for more info about [header](https://pptr.dev/api/pu
 
 This can be achieved with [MathJax](https://www.mathjax.org/). A simple example can be found in [`/src/test/mathjax`](/src/test/mathjax).
 
+#### Diagrams
+
+Diagrams can be rendered with [Mermaid](https://mermaid.js.org/), by loading it with the `script` option and turning the `mermaid` code blocks into elements that Mermaid picks up. Because Mermaid renders asynchronously, use `wait_for_function` to make sure that the output isn't generated before the diagrams are done. A complete example can be found in [`/src/test/mermaid`](/src/test/mermaid).
+
+```markdown
+---
+script:
+  - url: https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js
+  - path: mermaid-init.js
+wait_for_function: 'window.mermaidRendered === true'
+---
+```
+
+#### Waiting for Asynchronous Scripts
+
+Before generating the output, md-to-pdf waits until the network has been idle for a moment. That covers scripts that keep loading resources, but not work that finishes later on its own (e. g. a rendering library that is done a second after it was loaded) — such content is silently missing from the output.
+
+Set `wait_for_function` to a function (or a string containing an expression) that becomes truthy once the page is ready, and it will be polled with [`page.waitForFunction`](https://pptr.dev/api/puppeteer.page.waitforfunction) before the PDF or HTML is generated.
+
+```js
+module.exports = {
+	script: [
+		{ url: 'https://example.org/chart-library.js' },
+		{ content: 'renderCharts().then(() => (window.charted = true))' },
+	],
+	wait_for_function: () => window.charted === true,
+};
+```
+
 #### Default and Advanced Options
 
 For default and advanced options see the following links. The default highlight.js styling for code blocks is `github`. The default PDF options are the A4 format and some margin (see `lib/config.ts` for the full default config).
@@ -198,6 +227,7 @@ For default and advanced options see the following links. The default highlight.
 | `--md-file-encoding`    | `utf-8`, `windows1252`                                                |
 | `--stylesheet-encoding` | `utf-8`, `windows1252`                                                |
 | `--config-file`         | `path/to/config.json`                                                 |
+| `--wait-for-function`   | `'window.isRendered === true'`                                        |
 
 **`margin`:** instead of an object (as stated in the Puppeteer docs), it is also possible to pass a CSS-like string, e. g. `1em` (all), `1in 2in` (top/bottom right/left), `10mm 20mm 30mm` (top right/left bottom) or `1px 2px 3px 4px` (top right bottom left).
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ export const cliFlags = arg({
 	'--as-html': Boolean,
 	'--config-file': String,
 	'--devtools': Boolean,
+	'--wait-for-function': String,
 
 	// aliases
 	'-h': '--help',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -173,6 +173,17 @@ interface BasicConfig {
 	 * @see https://marked.js.org/using_pro#extensions
 	 */
 	marked_extensions: marked.MarkedExtension[];
+
+	/**
+	 * A function (or a string containing an expression) that is polled in the
+	 * page until it returns a truthy value, before the output is generated.
+	 *
+	 * This is useful when a script that is loaded via the `script` option
+	 * renders something asynchronously, e. g. Mermaid diagrams.
+	 *
+	 * @see https://pptr.dev/api/puppeteer.page.waitforfunction
+	 */
+	wait_for_function?: string | (() => unknown);
 }
 
 export type PuppeteerLaunchOptions = Parameters<typeof launch>[0];

--- a/src/lib/generate-output.ts
+++ b/src/lib/generate-output.ts
@@ -89,6 +89,14 @@ export async function generateOutput(
 	}
 
 	/**
+	 * Scripts that render asynchronously (e. g. Mermaid) are not covered by the
+	 * network idle check below, so give them a chance to signal completion.
+	 */
+	if (config.wait_for_function) {
+		await page.waitForFunction(config.wait_for_function);
+	}
+
+	/**
 	 * Trick to wait for network to be idle.
 	 *
 	 * @todo replace with page.waitForNetworkIdle once exposed

--- a/src/lib/help.ts
+++ b/src/lib/help.ts
@@ -26,6 +26,7 @@ const helpText = `
     --as-html ${chalk.dim('................')} Output as HTML instead
     --config-file ${chalk.dim('............')} Path to a JSON or JS configuration file
     --devtools ${chalk.dim('...............')} Open the browser with devtools instead of creating PDF
+    --wait-for-function ${chalk.dim('......')} Expression that is polled in the page before the output is generated
 
   ${chalk.dim.underline.bold('Examples:')}
 

--- a/src/test/api.spec.ts
+++ b/src/test/api.spec.ts
@@ -16,6 +16,16 @@ const getPdfTextContent = async (content: Buffer) => {
 	return textContent;
 };
 
+/**
+ * Appends `<p>rendered</p>` to the page, but only after the network has long been idle.
+ *
+ * The marker is assembled at runtime so that it doesn't show up in the page as part of the script tag itself.
+ */
+const delayedScript = `setTimeout(() => {
+	document.body.insertAdjacentHTML('beforeend', '<p>' + 'render' + 'ed</p>');
+	window.isRendered = true;
+}, 1500);`;
+
 before(() => {
 	const filesToDelete = [resolve(__dirname, 'basic', 'api-test.pdf'), resolve(__dirname, 'basic', 'api-test.html')];
 
@@ -89,6 +99,23 @@ test('compile the MathJax test', async (t) => {
 
 	t.true(textContent.startsWith('Formulas with MathJax'));
 	t.regex(textContent, /a\s≠\s0/);
+});
+
+test('`wait_for_function` waits for asynchronously rendered content', async (t) => {
+	const html = await mdToPdf(
+		{ content: '# Async' },
+		{ as_html: true, script: [{ content: delayedScript }], wait_for_function: 'window.isRendered === true' },
+	);
+
+	// without the option this content is missing, because the network goes idle long before the script is done
+	t.true(html.content.includes('<p>rendered</p>'));
+});
+
+test('compile the Mermaid test', async (t) => {
+	const html = await mdToPdf({ path: resolve(__dirname, 'mermaid', 'diagram.md') }, { as_html: true });
+
+	t.true(html.content.includes('<svg'));
+	t.true(html.content.includes('Puppeteer'));
 });
 
 test('the JS engine with `js` tag is disabled by default', async (t) => {

--- a/src/test/mermaid/diagram.md
+++ b/src/test/mermaid/diagram.md
@@ -1,0 +1,13 @@
+---
+script:
+  - url: https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js
+  - path: src/test/mermaid/mermaid-init.js
+wait_for_function: 'window.mermaidRendered === true'
+---
+
+# Diagrams with Mermaid
+
+```mermaid
+graph LR
+    Markdown --> Puppeteer --> PDF
+```

--- a/src/test/mermaid/mermaid-init.js
+++ b/src/test/mermaid/mermaid-init.js
@@ -1,0 +1,16 @@
+// Turn the highlighted `mermaid` code blocks into elements that Mermaid picks up.
+for (const code of document.querySelectorAll('pre > code.mermaid')) {
+	const div = document.createElement('div');
+
+	div.className = 'mermaid';
+	div.textContent = code.textContent;
+
+	code.parentElement.replaceWith(div);
+}
+
+mermaid.initialize({ startOnLoad: false });
+
+// Mermaid renders asynchronously, so signal completion for `wait_for_function`.
+mermaid.run().then(() => {
+	window.mermaidRendered = true;
+});


### PR DESCRIPTION
## Problem

Scripts loaded via the `script` option can render asynchronously, but there is no way to wait for them. The network idle check in `generate-output.ts` only covers work that keeps network requests in flight — anything that finishes on its own a moment later is silently missing from the output, with no warning.

Measured on master with a script that appends to the body after a delay (`--as-html`, so the output is easy to check):

| delay before the script is done | content in the output? |
| ------------------------------- | ---------------------- |
| 100 ms                          | yes                    |
| 400 ms                          | yes                    |
| 1000 ms                         | **no**                 |
| 3000 ms                         | **no**                 |

With `wait_for_function`, all of them are included.

## Solution

A `wait_for_function` config option (plus `--wait-for-function`), polled with [`page.waitForFunction`](https://pptr.dev/api/puppeteer.page.waitforfunction) after the script tags are added and before the output is generated. It accepts a function or a string containing an expression, so it works from a JS config file as well as from front-matter and the CLI. It's opt-in and does nothing when unset.

```js
module.exports = {
	script: [
		{ url: 'https://example.org/chart-library.js' },
		{ content: 'renderCharts().then(() => (window.charted = true))' },
	],
	wait_for_function: () => window.charted === true,
};
```

## Mermaid

This is what motivated the change, and it's the most upvoted open request (#124, #342). Rendering Mermaid works today only because it happens to finish inside the network idle window — it's a coincidence, not a guarantee, and it doesn't hold for anything that resolves later (lazily loaded diagram modules, web fonts, slower machines).

Rather than pulling Mermaid into the core, this follows what you suggested in #124 and keeps it in userland, where the only missing piece was the ability to wait. `/src/test/mermaid` is a complete working example in the same shape as `/src/test/mathjax`, and the readme now documents it:

```markdown
---
script:
  - url: https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js
  - path: mermaid-init.js
wait_for_function: 'window.mermaidRendered === true'
---
```

This is complementary to #353 rather than a competing approach — that one adds a `--mermaid` flag to the core, this one adds the general primitive it (and MathJax, and chart libraries) needs.

## Tests

- `wait_for_function` waits for asynchronously rendered content — fails on master, passes here.
- `compile the Mermaid test` — renders `/src/test/mermaid/diagram.md` and asserts the SVG is in the output.

Verified locally: `xo` clean (the one remaining `complexity` warning in `md-to-pdf.ts` is pre-existing), `tsc -p tsconfig.type-test.json` clean, `lib.spec.ts` and `cli.spec.ts` pass. The `pdfjs-dist` tests in `api.spec.ts` couldn't run on this machine (`canvas@2.11.2` has no arm64 prebuild), so the new tests there were run against a copy of the file with the pdfjs imports removed — all 7 pass. Worth a look in CI.
